### PR TITLE
feat - create note screen

### DIFF
--- a/css/create-note.css
+++ b/css/create-note.css
@@ -1,0 +1,30 @@
+.add-note-box {
+  width: 100%;
+}
+
+.add-note-title,
+.add-note-content {
+  outline: none;
+  width: 100%;
+  padding: 4px;
+}
+
+.add-note-content {
+  resize: none;
+}
+
+.add-note-footer {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.btn-close {
+  color: var(--black-700);
+  margin-left: auto;
+}
+
+.note-action-icons .btn-icon {
+  font-size: 1.5rem;
+}

--- a/screens/create-note.html
+++ b/screens/create-note.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <link rel="stylesheet" href="https://rocket-ui.vercel.app/css/main.css" />
+    <link rel="stylesheet" href="../styles.css">
+    <link rel="stylesheet" href="../css/create-note.css">
+    <title>Cakeopedia | Add Note</title>
+</head>
+
+<body>
+    <!--add note -->
+    <main>
+        <div class="add-note-modal dialog-window">
+            <div class="dialog-box add-note-box">
+                <div class="dialog-header txt txt-bold txt-md">
+                    <input type="text" name="" id="" class="add-note-title" placeholder="Title">
+                </div>
+                <div class="dialog-body">
+                    <textarea name="" id="" rows="15" class="add-note-content" placeholder="Take a note..."></textarea>
+                </div>
+                <div class="dialog-footer add-note-footer">
+                    <div class="note-action-icons">
+                        <button class="btn-icon material-icons ">color_lens</button>
+                        <button class="btn-icon material-icons ">image</button>
+                        <button class="btn-icon material-icons ">check_box</button>
+                        <button class="btn-icon material-icons ">bookmark_add</button>
+                        <button class="btn-icon material-icons ">content_copy</button>
+                        <button class="btn-icon material-icons ">delete</button></div>
+                    <a class="btn-link btn-close txt-bold p-2">Close</a>
+                </div>
+            </div>
+        </div>
+    </main>
+</body>
+
+</html>


### PR DESCRIPTION
This screen will open as a modal when the user clicks on 'add note' button in view notes page

<img width="960" alt="image" src="https://user-images.githubusercontent.com/64582473/154558172-a8ab55de-bd28-417a-82a5-ba89e064706b.png">

![mini - create note2](https://user-images.githubusercontent.com/64582473/154559242-9d375a39-14b6-4c2e-aa2e-dc438aa4d454.gif)

